### PR TITLE
Update test-kitchen, CentOS to 6.6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,7 +18,7 @@ platforms:
     run_list:
       - apt::default
       - jenkins::java
-  - name: centos-6.4
+  - name: centos-6.6
     run_list:
       - yum::default
       - jenkins::java


### PR DESCRIPTION
Failed to find CentOS 6.4 so updating to 6.6